### PR TITLE
Snippets for adding propTypes and creating empty state object

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `rscp→`  | stateless component with prop types skeleton |
 | `con→`   | class default constructor with props|
 | `conc→`  | class default constructor with props and context |
+| `est→`   | empty state object |
 | `cwm→`   | `componentWillMount method` |
 | `cdm→`   | `componentDidMount method` |
 | `cwr→`   | `componentWillReceiveProps method` |
@@ -62,6 +63,7 @@ For example ```pta``` creates the ```PropTypes.array``` and ```ptar``` creates t
 
 | Trigger  | Content |
 | -------: | ------- |
+| `rpt→`   | empty propTypes declaration |
 | `pta→`   | `PropTypes.array,` |
 | `ptar→`  | `PropTypes.array.isRequired,` |
 | `ptb→`   | `PropTypes.bool,` |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -45,6 +45,12 @@
     "description": "Adds a default construcotr for the class that contains props and context as arguments"
   },
   
+  "emptyState": {
+    "prefix": "est",
+    "body": "this.state = {\n\t$1\n};",
+    "description": "Creates empty state object. To be used in a constructor."
+  }
+  
   "componentWillMount": {
     "prefix": "cwm",
     "body": "\ncomponentWillMount() {\n\t$0\n}\n",
@@ -121,6 +127,12 @@
     "prefix": "bnd",
 	"body": "this.$1 = this.$1.bind(this);$0",
 	"description": "Access component's state"
+  },
+  
+  "propTypes": {
+	"prefix": "rpt",
+	"body": "$1.propTypes = {\n\t$2\n};",
+	"description": "Creates empty propTypes declaration"
   },
   
   "propTypeArray": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -49,7 +49,7 @@
     "prefix": "est",
     "body": "this.state = {\n\t$1\n};",
     "description": "Creates empty state object. To be used in a constructor."
-  }
+  },
   
   "componentWillMount": {
     "prefix": "cwm",


### PR DESCRIPTION
I added snippets for adding propTypes after the class declaration (rpt) and for creating an empty state object within a constructor (est). I find them very useful during my React development so I hope others would also appreciate them.
