### PR TITLE
import/export styles, MobX additions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `rcfc→`  | class component skeleton that contains all the lifecycle methods |
 | `rsc→`   | stateless component skeleton |
 | `rscp→`  | stateless component with prop types skeleton |
+| `rmcc→`  | mobx class component skeleton |
+| `rmsc→`  | mobx stateless component skeleton |
 | `rpt→`   | empty propTypes declaration |
 | `con→`   | class default constructor with props|
 | `conc→`  | class default constructor with props and context |

--- a/README.md
+++ b/README.md
@@ -43,11 +43,12 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `rccp→`  | class component skeleton with prop types after the class |
 | `rcjc→`  | class component skeleton without import and default export lines |
 | `rcfc→`  | class component skeleton that contains all the lifecycle methods |
-| `rsc→`   | stateless component skeleton |
+| `rsc→`   | inline stateless component skeleton |
+| `rscb→`  | stateless component skeleton |
 | `rscp→`  | stateless component with prop types skeleton |
 | `rmcc→`  | mobx class component skeleton |
-| `rmsc→`  | mobx stateless component skeleton |
-| `rmscb→` | mobx stateless component with braces skeleton |
+| `rmsc→`  | mobx inline stateless component skeleton |
+| `rmscb→` | mobx stateless component skeleton |
 | `rpt→`   | empty propTypes declaration |
 | `con→`   | class default constructor with props|
 | `conc→`  | class default constructor with props and context |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `rmjcc→` | mobx class component skeleton without import or default export |
 | `rmccp→` | mobx class component default export skeleton with prop types |
 | `rmjccp→`| mobx class component skeleton with prop types, without import or default export |
-
 | `rsc→`   | inline SFC default export skeleton |
 | `rscb→`  | SFC default export skeleton |
 | `rjsc→`  | inline SFC without import or export |
@@ -56,7 +55,6 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `rscbp→` | SFC with prop types default export skeleton |
 | `rjscp→` | inline SFC with prop types, without import or export |
 | `rjscbp→`| SFC with prop types, without import or export |
-
 | `rmsc→`   | mobx inline SFC default export skeleton |
 | `rmscb→`  | mobx SFC default export skeleton |
 | `rmjsc→`  | mobx inline SFC without import or export |
@@ -65,9 +63,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `rmscbp→` | mobx SFC with prop types default export skeleton |
 | `rmjscp→` | mobx inline SFC with prop types, without import or export |
 | `rmjscbp→`| mobx SFC with prop types, without import or export |
-
 | `rcfc→`  | class component skeleton that contains all the lifecycle methods |
-
 | `rpt→`   | empty propTypes declaration |
 | `con→`   | class default constructor with props|
 | `conc→`  | class default constructor with props and context |

--- a/README.md
+++ b/README.md
@@ -39,16 +39,35 @@ Below is a list of all available snippets and the triggers of each one. The **�
 
 | Trigger  | Content |
 | -------: | ------- |
-| `rcc→`   | class component skeleton |
-| `rccp→`  | class component skeleton with prop types after the class |
-| `rcjc→`  | class component skeleton without import and default export lines |
+| `rcc→`   | class component default export skeleton |
+| `rjcc→`  | class component skeleton without import of default export |
+| `rccp→`  | class component default export skeleton with prop types |
+| `rjccp→` | class component skeleton with prop types, without import or default export |
+| `rmcc→`  | mobx class component default export skeleton |
+| `rmjcc→` | mobx class component skeleton without import or default export |
+| `rmccp→` | mobx class component default export skeleton with prop types |
+| `rmjccp→`| mobx class component skeleton with prop types, without import or default export |
+
+| `rsc→`   | inline SFC default export skeleton |
+| `rscb→`  | SFC default export skeleton |
+| `rjsc→`  | inline SFC without import or export |
+| `rjscb→` | SFC without import or export |
+| `rscp→`  | inline SFC with prop types default export skeleton |
+| `rscbp→` | SFC with prop types default export skeleton |
+| `rjscp→` | inline SFC with prop types, without import or export |
+| `rjscbp→`| SFC with prop types, without import or export |
+
+| `rmsc→`   | mobx inline SFC default export skeleton |
+| `rmscb→`  | mobx SFC default export skeleton |
+| `rmjsc→`  | mobx inline SFC without import or export |
+| `rmjscb→` | mobx SFC without import or export |
+| `rmscp→`  | mobx inline SFC with prop types default export skeleton |
+| `rmscbp→` | mobx SFC with prop types default export skeleton |
+| `rmjscp→` | mobx inline SFC with prop types, without import or export |
+| `rmjscbp→`| mobx SFC with prop types, without import or export |
+
 | `rcfc→`  | class component skeleton that contains all the lifecycle methods |
-| `rsc→`   | inline stateless component skeleton |
-| `rscb→`  | stateless component skeleton |
-| `rscp→`  | stateless component with prop types skeleton |
-| `rmcc→`  | mobx class component skeleton |
-| `rmsc→`  | mobx inline stateless component skeleton |
-| `rmscb→` | mobx stateless component skeleton |
+
 | `rpt→`   | empty propTypes declaration |
 | `con→`   | class default constructor with props|
 | `conc→`  | class default constructor with props and context |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `rscp→`  | stateless component with prop types skeleton |
 | `rmcc→`  | mobx class component skeleton |
 | `rmsc→`  | mobx stateless component skeleton |
+| `rmscb→` | mobx stateless component with braces skeleton |
 | `rpt→`   | empty propTypes declaration |
 | `con→`   | class default constructor with props|
 | `conc→`  | class default constructor with props and context |

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -4,19 +4,21 @@
     "body": "import React, {Component} from 'react';\n\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
     "description": "Creates a React component class with default export"
   },
-
-  "reactMobxClassCompoment": {
-    "prefix": "rmcc",
-    "body": "import React, {Component} from 'react';\nimport {observer} from 'mobx-react';\n\n@observer\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
-    "description": "Creates a React component class with default export"
-  },  
-
   "reactJustClassCompoment": {
     "prefix": "rcjc",
     "body": "class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n",
     "description": "Creates a React component class"
   },
-
+  "reactMobxClassCompoment": {
+    "prefix": "rmcc",
+    "body": "import React, {Component} from 'react';\nimport {observer} from 'mobx-react';\n\n@observer\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
+    "description": "Creates a MobX React component class with default export"
+  },
+  "reactMobxJustClassCompoment": {
+    "prefix": "rmjcc",
+    "body": "@observer\nclass ${componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
+    "description": "Creates a MobX React component class"
+  },
   "reactClassCompomentPropTypes": {
     "prefix": "rccp",
     "body": "import React, {Component, PropTypes} from 'react';\n\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\n};",
@@ -31,28 +33,48 @@
 
   "reactStateless": {
     "prefix": "rsc",
-    "body": "import React from 'react';\n\nexport default () => (\n\t<div>\n\t\t$0\n\t</div>\n);",
-    "description": "Creates an inline stateless React component with default export"
+    "body": "import React from 'react';\n\nexport default (${1:props}) => (\n\t<div>\n\t\t$1\n\t</div>\n);",
+    "description": "Creates an inline SFC with default export"
   },
   "reactStatelessBraces": {
     "prefix": "rscb",
-    "body": "import React from 'react';\n\nexport default () => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n};",
-    "description": "Creates a stateless React component with default export"
+    "body": "import React from 'react';\n\nexport default (${1:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n};",
+    "description": "Creates an SFC with default export"
+  },
+  "reactJustInlineStateless": {
+    "prefix": "rjsc",
+    "body": "const ${1:componentName} = (${2:props}) => (\n\t<div>\n\t\t$2\n\t</div>\n);",
+    "description": "Creates an inline SFC"
+  },
+  "reactJustStateless": {
+    "prefix": "rjscb",
+    "body": "const ${1:componentName} = (${2:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$2\n\t\t</div>\n\t);\n};",
+    "description": "Creates an SFC"
   },  
   "reactMobxStateless": {
     "prefix": "rmsc",
-    "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nexport default observer(() => (\n\t<div>\n\t\t$0\n\t</div>\n));",
-    "description": "Creates an inline MobX stateless React component with default export"
+    "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nexport default observer((${1:props}) => (\n\t<div>\n\t\t$0\n\t</div>\n));",
+    "description": "Creates an inline MobX SFC with default export"
   },
   "reactMobxStatelessBraces": {
     "prefix": "rmscb",
-    "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nexport default observer(() => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n});",
-    "description": "Creates a MobX stateless React component with default export"
+    "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nexport default observer((${1:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n});",
+    "description": "Creates a MobX SFC with default export"
+  },
+  "reactJustMobxInlineStateless": {
+    "prefix": "rmjsc",
+    "body": "const ${1:componentName} = observer((${2:props}) => (\n\t<div>\n\t\t$0\n\t</div>\n));",
+    "description": "Creates an inline MobX SFC"
+  },
+  "reactJustMobxStateless": {
+    "prefix": "rmjscb",
+    "body": "const ${1:componentName} = observer((${2:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n});",
+    "description": "Creates a MobX SFC"
   },
   "reactStatelessProps": {
     "prefix": "rscp",
     "body": "import React, {PropTypes} from 'react';\n\nconst ${1:componentName} = props => {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t);\n};\n\n${1:componentName}.propTypes = {\n\t$0\n};\n\nexport default ${1:componentName};",
-    "description": "Creates a stateless React component with PropTypes and default export"
+    "description": "Creates an SFC with PropTypes and default export"
   },
 
   "classConstructor": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,9 +1,15 @@
 {
   "reactClassCompoment": {
     "prefix": "rcc",
-    "body": "import React, { Component } from 'react';\n\nclass ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\nexport default ${1:componentName};",
+    "body": "import React, {Component} from 'react';\n\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n",
     "description": "Creates a React component class with ES6 module system"
   },
+
+  "reactMobxClassCompoment": {
+    "prefix": "rmcc",
+    "body": "import React, {Component} from 'react';\nimport {observer} from 'mobx-react';\n\n@observer\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n",
+    "description": "Creates a React component class with ES6 module system"
+  },  
 
   "reactJustClassCompoment": {
     "prefix": "rcjc",
@@ -13,24 +19,29 @@
 
   "reactClassCompomentPropTypes": {
     "prefix": "rccp",
-    "body": "import React, { Component, PropTypes } from 'react';\n\nclass ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\n};\n\nexport default ${1:componentName};",
+    "body": "import React, {Component, PropTypes} from 'react';\n\nclass ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\n};\n\nexport default ${1:componentName};",
     "description": "Creates a React component class with PropTypes and ES6 module system"
   },
 
   "reactClassCompomentWithMethods": {
     "prefix": "rcfc",
-    "body": "import React, { Component, PropTypes } from 'react';\n\nclass ${1:componentName} extends Component {\n\tconstructor(props) {\n\t\tsuper(props);\n\n\t}\n\n\tcomponentWillMount() {\n\n\t}\n\n\tcomponentDidMount() {\n\n\t}\n\n\tcomponentWillReceiveProps(nextProps) {\n\n\t}\n\n\tshouldComponentUpdate(nextProps, nextState) {\n\n\t}\n\n\tcomponentWillUpdate(nextProps, nextState) {\n\n\t}\n\n\tcomponentDidUpdate(prevProps, prevState) {\n\n\t}\n\n\tcomponentWillUnmount() {\n\n\t}\n\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\n};\n\nexport default ${1:componentName};",
+    "body": "import React, {Component, PropTypes} from 'react';\n\nclass ${1:componentName} extends Component {\n\tconstructor(props) {\n\t\tsuper(props);\n\n\t}\n\n\tcomponentWillMount() {\n\n\t}\n\n\tcomponentDidMount() {\n\n\t}\n\n\tcomponentWillReceiveProps(nextProps) {\n\n\t}\n\n\tshouldComponentUpdate(nextProps, nextState) {\n\n\t}\n\n\tcomponentWillUpdate(nextProps, nextState) {\n\n\t}\n\n\tcomponentDidUpdate(prevProps, prevState) {\n\n\t}\n\n\tcomponentWillUnmount() {\n\n\t}\n\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\n};\n\nexport default ${1:componentName};",
     "description": "Creates a React component class with PropTypes and all lifecycle methods and ES6 module system"
   },
 
   "reactStateless": {
     "prefix": "rsc",
-    "body": "import React from 'react';\n\nconst ${1:componentName} = () => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n};\n\nexport default ${1:componentName};",
+    "body": "import React from 'react';\n\nexport default () => (\n\t<div>\n\t\t$0\n\t</div>\n);\n\n",
     "description": "Creates a stateless React component without PropTypes and ES6 module system"
   },
+  "reactMobxStateless": {
+    "prefix": "rmsc",
+    "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nexport default observer(() => (\n\t<div>\n\t\t$0\n\t</div>\n));\n\n",
+    "description": "Creates a stateless React component without PropTypes and ES6 module system"
+  },  
   "reactStatelessProps": {
     "prefix": "rscp",
-    "body": "import React, { PropTypes } from 'react';\n\nconst ${1:componentName} = props => {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t);\n};\n\n${1:componentName}.propTypes = {\n\t$0\n};\n\nexport default ${1:componentName};",
+    "body": "import React, {PropTypes} from 'react';\n\nconst ${1:componentName} = props => {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t);\n};\n\n${1:componentName}.propTypes = {\n\t$0\n};\n\nexport default ${1:componentName};",
     "description": "Creates a stateless React component with PropTypes and ES6 module system"
   },
 

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -1,48 +1,58 @@
 {
   "reactClassCompoment": {
     "prefix": "rcc",
-    "body": "import React, {Component} from 'react';\n\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n",
-    "description": "Creates a React component class with ES6 module system"
+    "body": "import React, {Component} from 'react';\n\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
+    "description": "Creates a React component class with default export"
   },
 
   "reactMobxClassCompoment": {
     "prefix": "rmcc",
-    "body": "import React, {Component} from 'react';\nimport {observer} from 'mobx-react';\n\n@observer\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n",
-    "description": "Creates a React component class with ES6 module system"
+    "body": "import React, {Component} from 'react';\nimport {observer} from 'mobx-react';\n\n@observer\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
+    "description": "Creates a React component class with default export"
   },  
 
   "reactJustClassCompoment": {
     "prefix": "rcjc",
     "body": "class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n",
-    "description": "Creates a React component class with ES6 module system"
+    "description": "Creates a React component class"
   },
 
   "reactClassCompomentPropTypes": {
     "prefix": "rccp",
-    "body": "import React, {Component, PropTypes} from 'react';\n\nclass ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\n};\n\nexport default ${1:componentName};",
-    "description": "Creates a React component class with PropTypes and ES6 module system"
+    "body": "import React, {Component, PropTypes} from 'react';\n\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\n};",
+    "description": "Creates a React component class with PropTypes and default export"
   },
 
   "reactClassCompomentWithMethods": {
     "prefix": "rcfc",
-    "body": "import React, {Component, PropTypes} from 'react';\n\nclass ${1:componentName} extends Component {\n\tconstructor(props) {\n\t\tsuper(props);\n\n\t}\n\n\tcomponentWillMount() {\n\n\t}\n\n\tcomponentDidMount() {\n\n\t}\n\n\tcomponentWillReceiveProps(nextProps) {\n\n\t}\n\n\tshouldComponentUpdate(nextProps, nextState) {\n\n\t}\n\n\tcomponentWillUpdate(nextProps, nextState) {\n\n\t}\n\n\tcomponentDidUpdate(prevProps, prevState) {\n\n\t}\n\n\tcomponentWillUnmount() {\n\n\t}\n\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\n};\n\nexport default ${1:componentName};",
-    "description": "Creates a React component class with PropTypes and all lifecycle methods and ES6 module system"
+    "body": "import React, {Component, PropTypes} from 'react';\n\nexport default class ${1:componentName} extends Component {\n\tconstructor(props) {\n\t\tsuper(props);\n\n\t}\n\n\tcomponentWillMount() {\n\n\t}\n\n\tcomponentDidMount() {\n\n\t}\n\n\tcomponentWillReceiveProps(nextProps) {\n\n\t}\n\n\tshouldComponentUpdate(nextProps, nextState) {\n\n\t}\n\n\tcomponentWillUpdate(nextProps, nextState) {\n\n\t}\n\n\tcomponentDidUpdate(prevProps, prevState) {\n\n\t}\n\n\tcomponentWillUnmount() {\n\n\t}\n\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\n};",
+    "description": "Creates a React component class with PropTypes, all lifecycle methods and default export"
   },
 
   "reactStateless": {
     "prefix": "rsc",
-    "body": "import React from 'react';\n\nexport default () => (\n\t<div>\n\t\t$0\n\t</div>\n);\n\n",
-    "description": "Creates a stateless React component without PropTypes and ES6 module system"
+    "body": "import React from 'react';\n\nexport default () => (\n\t<div>\n\t\t$0\n\t</div>\n);",
+    "description": "Creates an inline stateless React component with default export"
   },
+  "reactStatelessBraces": {
+    "prefix": "rscb",
+    "body": "import React from 'react';\n\nexport default () => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n};",
+    "description": "Creates a stateless React component with default export"
+  },  
   "reactMobxStateless": {
     "prefix": "rmsc",
-    "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nexport default observer(() => (\n\t<div>\n\t\t$0\n\t</div>\n));\n\n",
-    "description": "Creates a stateless React component without PropTypes and ES6 module system"
-  },  
+    "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nexport default observer(() => (\n\t<div>\n\t\t$0\n\t</div>\n));",
+    "description": "Creates an inline MobX stateless React component with default export"
+  },
+  "reactMobxStatelessBraces": {
+    "prefix": "rmscb",
+    "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nexport default observer(() => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n});",
+    "description": "Creates a MobX stateless React component with default export"
+  },
   "reactStatelessProps": {
     "prefix": "rscp",
     "body": "import React, {PropTypes} from 'react';\n\nconst ${1:componentName} = props => {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t);\n};\n\n${1:componentName}.propTypes = {\n\t$0\n};\n\nexport default ${1:componentName};",
-    "description": "Creates a stateless React component with PropTypes and ES6 module system"
+    "description": "Creates a stateless React component with PropTypes and default export"
   },
 
   "classConstructor": {
@@ -59,7 +69,13 @@
   "emptyState": {
     "prefix": "est",
     "body": "this.state = {\n\t$1\n};",
-    "description": "Creates empty state object. To be used in a constructor."
+    "description": "Creates an empty state object. To be used in a constructor."
+  },
+
+  "emptyStateProp": {
+    "prefix": "estp",
+    "body": "state = {$1};",
+    "description": "Creates an empty state object. To be used as a class property."
   },
 
   "componentWillMount": {

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -5,25 +5,42 @@
     "description": "Creates a React component class with default export"
   },
   "reactJustClassCompoment": {
-    "prefix": "rcjc",
-    "body": "class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n",
+    "prefix": "rjcc",
+    "body": "class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
     "description": "Creates a React component class"
   },
+  "reactClassCompomentPropTypes": {
+    "prefix": "rccp",
+    "body": "import React, {Component, PropTypes} from 'react';\n\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\t$2\n};",
+    "description": "Creates a React component class with PropTypes and default export"
+  },
+  "reactJustClassCompomentProps": {
+    "prefix": "rjccp",
+    "body": "class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n$2\n};",
+    "description": "Creates a React component class with PropTypes"
+  },
+
   "reactMobxClassCompoment": {
     "prefix": "rmcc",
-    "body": "import React, {Component} from 'react';\nimport {observer} from 'mobx-react';\n\n@observer\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
+    "body": "import React, {Component, PropTypes} from 'react';\nimport {observer} from 'mobx-react';\n\n@observer\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
     "description": "Creates a MobX React component class with default export"
   },
   "reactMobxJustClassCompoment": {
     "prefix": "rmjcc",
-    "body": "@observer\nclass ${componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
+    "body": "@observer\nclass ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}",
     "description": "Creates a MobX React component class"
   },
-  "reactClassCompomentPropTypes": {
-    "prefix": "rccp",
-    "body": "import React, {Component, PropTypes} from 'react';\n\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\n};",
-    "description": "Creates a React component class with PropTypes and default export"
+  "reactMobxClassCompomentProps": {
+    "prefix": "rmccp",
+    "body": "import React, {Component, PropTypes} from 'react';\nimport {observer} from 'mobx-react';\n\n@observer\nexport default class ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\t$2\n};",
+    "description": "Creates a MobX React component class with PropTypes and default export"
   },
+  "reactMobxJustClassCompomentProps": {
+    "prefix": "rmjccp",
+    "body": "@observer\nclass ${1:componentName} extends Component {\n\trender() {\n\t\treturn (\n\t\t\t<div>\n\t\t\t\t$0\n\t\t\t</div>\n\t\t);\n\t}\n}\n\n${1:componentName}.propTypes = {\n\t$2\n};",
+    "description": "Creates a MobX React component class with PropTypes"
+  },
+  
 
   "reactClassCompomentWithMethods": {
     "prefix": "rcfc",
@@ -31,9 +48,10 @@
     "description": "Creates a React component class with PropTypes, all lifecycle methods and default export"
   },
 
+
   "reactStateless": {
     "prefix": "rsc",
-    "body": "import React from 'react';\n\nexport default (${1:props}) => (\n\t<div>\n\t\t$1\n\t</div>\n);",
+    "body": "import React from 'react';\n\nexport default (${1:props}) => (\n\t<div>\n\t\t$0\n\t</div>\n);",
     "description": "Creates an inline SFC with default export"
   },
   "reactStatelessBraces": {
@@ -43,14 +61,38 @@
   },
   "reactJustInlineStateless": {
     "prefix": "rjsc",
-    "body": "const ${1:componentName} = (${2:props}) => (\n\t<div>\n\t\t$2\n\t</div>\n);",
+    "body": "const ${1:componentName} = (${2:props}) => (\n\t<div>\n\t\t$0\n\t</div>\n);",
     "description": "Creates an inline SFC"
   },
   "reactJustStateless": {
     "prefix": "rjscb",
-    "body": "const ${1:componentName} = (${2:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$2\n\t\t</div>\n\t);\n};",
+    "body": "const ${1:componentName} = (${2:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n};",
     "description": "Creates an SFC"
-  },  
+  },
+
+  "reactStatelessProps": {
+    "prefix": "rscp",
+    "body": "import React, {PropTypes} from 'react';\n\nconst ${1:componentName} = (${2:props}) => (\n\t<div>\n\t\t$0\n\t</div>\n);\n\n${1:componentName}.propTypes = {\n\t$3\n};\n\nexport default ${1:componentName};",
+    "description": "Creates an inline SFC with PropTypes and default export"
+  },
+  "reactStatelessBracesProps": {
+    "prefix": "rscbp",
+    "body": "import React, {PropTypes} from 'react';\n\nconst ${1:componentName} = (${2:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n};\n\n${1:componentName}.propTypes = {\n\t$3\n};\n\nexport default ${1:componentName};",
+    "description": "Creates an SFC with PropTypes and default export"
+  },
+  "reactJustInlineStatelessProps": {
+    "prefix": "rjscp",
+    "body": "const ${1:componentName} = (${2:props}) => (\n\t<div>\n\t\t$0\n\t</div>\n);\n\n${1:componentName}.propTypes = {\n\t$3\n};\n\nexport default ${1:componentName};",
+    "description": "Creates an inline SFC with PropTypes"
+  },
+  "reactJustStatelessProps": {
+    "prefix": "rjscbp",
+    "body": "const ${1:componentName} = (${2:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n};\n\n${1:componentName}.propTypes = {\n\t$3\n};\n\nexport default ${1:componentName};",
+    "description": "Creates an SFC with PropTypes"
+  },
+
+
+
   "reactMobxStateless": {
     "prefix": "rmsc",
     "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nexport default observer((${1:props}) => (\n\t<div>\n\t\t$0\n\t</div>\n));",
@@ -71,11 +113,29 @@
     "body": "const ${1:componentName} = observer((${2:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n});",
     "description": "Creates a MobX SFC"
   },
-  "reactStatelessProps": {
-    "prefix": "rscp",
-    "body": "import React, {PropTypes} from 'react';\n\nconst ${1:componentName} = props => {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t);\n};\n\n${1:componentName}.propTypes = {\n\t$0\n};\n\nexport default ${1:componentName};",
-    "description": "Creates an SFC with PropTypes and default export"
+  "reactMobxStatelessProps": {
+    "prefix": "rmscp",
+    "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nconst ${1:componentName} = observer((${2:props}) => (\n\t<div>\n\t\t$0\n\t</div>\n));\n\n${1:componentName}.propTypes = {\n\t$3\n};\n\nexport default ${1:componentName};",
+    "description": "Creates an inline MobX SFC with default export"
   },
+  "reactMobxStatelessBracesProps": {
+    "prefix": "rmscbp",
+    "body": "import React from 'react';\nimport {observer} from 'mobx-react';\n\nconst ${1:componentName} = observer((${2:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n});\n\n${1:componentName}.propTypes = {\n\t$3\n};\n\nexport default ${1:componentName};",
+    "description": "Creates a MobX SFC with default export"
+  },
+  "reactJustMobxInlineStatelessProps": {
+    "prefix": "rmjscp",
+    "body": "const ${1:componentName} = observer((${2:props}) => (\n\t<div>\n\t\t$0\n\t</div>\n));\n\n${1:componentName}.propTypes = {\n\t$3\n};\n\n",
+    "description": "Creates an inline MobX SFC"
+  },
+  "reactJustMobxStatelessProps": {
+    "prefix": "rmjscbp",
+    "body": "const ${1:componentName} = observer((${2:props}) => {\n\treturn (\n\t\t<div>\n\t\t\t$0\n\t\t</div>\n\t);\n});\n\n${1:componentName}.propTypes = {\n\t$3\n};\n\n",
+    "description": "Creates a MobX SFC"
+  },  
+
+
+
 
   "classConstructor": {
     "prefix": "con",


### PR DESCRIPTION
I sent you a note on Twitter, but I don't know how often you check that.  Basically, this adds mobx helpers: sfc's and class components, both with observer applied. 

I also changed some styling, basically moving the `export default` up inline with the class / arrow definition, to cut down on some boilerplate. I moved SFCs to be inline, with a new option to spit one out with braces.

Also plan to add more mobx goodies, class action methods/properties, computed properties, etc.

If you don't want these changes then totally fine - I'm happy to just have them be local, for myself.  But wanted to at least give you the choice :)