### PR TITLE
Add named function snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `rpc→`   | class pure component skeleton with prop types after the class |
 | `rsc→`   | stateless component skeleton |
 | `rscp→`  | stateless component with prop types skeleton |
-| `rpt→`   | empty propTypes declaration |
+| `rsf→`   | stateless named function skeleton |
+| `rsfp→`   | stateless named function with prop types skeleton |
+| `rpt→`   | empty propTypes declaration |
 | `rdp→`   | empty defaultProps declaration |
 | `con→`   | class default constructor with props|
 | `conc→`  | class default constructor with props and context |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Below is a list of all available snippets and the triggers of each one. The **�
 | `rsc→`   | stateless component skeleton |
 | `rscp→`  | stateless component with prop types skeleton |
 | `rsf→`   | stateless named function skeleton |
-| `rsfp→`   | stateless named function with prop types skeleton |
+| `rsfp→`  | stateless named function with prop types skeleton |
 | `rpt→`   | empty propTypes declaration |
 | `rdp→`   | empty defaultProps declaration |
 | `con→`   | class default constructor with props|

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -51,6 +51,16 @@
     "body": "import React from 'react';\nimport PropTypes from 'prop-types';\n\nconst ${1:${TM_FILENAME_BASE}} = props => {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t);\n};\n\n${1:${TM_FILENAME_BASE}}.propTypes = {\n\t$0\n};\n\nexport default ${1:${TM_FILENAME_BASE}};",
     "description": "Creates a stateless React component with PropTypes and ES6 module system"
   },
+  "reactStatelessFunction": {
+    "prefix": "rsf",
+    "body": "import React from 'react';\n\nfunction ${1:${TM_FILENAME_BASE}(props) {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t);\n}\n\nexport default ${1:${TM_FILENAME_BASE}};",
+    "description": "Creates a stateless React component as a named function without PropTypes"
+  },
+  "reactStatelessFunctionProps": {
+    "prefix": "rsf",
+    "body": "import React from 'react';\nimport PropTypes from 'prop-types';\n\n${1:${TM_FILENAME_BASE}}.propTypes = {\n\t$0\n};\n\nfunction ${1:${TM_FILENAME_BASE}(props) {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t);\n}\n\nexport default ${1:${TM_FILENAME_BASE}};",
+    "description": "Creates a stateless React component as a named function with PropTypes"
+  },
 
   "classConstructor": {
     "prefix": "con",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -57,7 +57,7 @@
     "description": "Creates a stateless React component as a named function without PropTypes"
   },
   "reactStatelessFunctionProps": {
-    "prefix": "rsf",
+    "prefix": "rsfp",
     "body": "import React from 'react';\nimport PropTypes from 'prop-types';\n\n${1:${TM_FILENAME_BASE}}.propTypes = {\n\t$0\n};\n\nfunction ${1:${TM_FILENAME_BASE}(props) {\n\treturn (\n\t\t<div>\n\t\t\t\n\t\t</div>\n\t);\n}\n\nexport default ${1:${TM_FILENAME_BASE}};",
     "description": "Creates a stateless React component as a named function with PropTypes"
   },


### PR DESCRIPTION
Without some babel configuration, it's impossible to list prop types at the top of the file when using arrow function components. [Many React developers](https://engineering.musefind.com/our-best-practices-for-writing-react-components-dec3eb5c3fc8) like to use named functions so that prop type definitions can exist at the top of the file - acting as a sort of documentation.

These two snippets will generate the following:

```javascript
import React from 'react';

function Footer(props) {
  return (
    <div>
      
    </div>
  );
};

export default Footer;
```

```javascript
import React from 'react';
import PropTypes from 'prop-types';

Footer.propTypes = {
  
};

function Footer(props) {
  return (
    <div>
      
    </div>
  );
};

export default Footer;
```