### PR TITLE
Removed extra dot on PropTypes.object

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For example ```pta``` creates the ```PropTypes.array``` and ```ptar``` creates t
 | `ptfr→`  | `PropTypes.func.isRequired,` |
 | `ptn→`   | `PropTypes.number,` |
 | `ptnr→`  | `PropTypes.number.isRequired,` |
-| `pto→`   | `PropTypes.object.,` |
+| `pto→`   | `PropTypes.object,` |
 | `ptor→`  | `PropTypes.object.isRequired,` |
 | `pts→`   | `PropTypes.string,` |
 | `ptsr→`  | `PropTypes.string.isRequired,` |


### PR DESCRIPTION
It's outputting
`PropTypes.object,`
but in the readme, there was an extra dot:
`PropTypes.object.,`