### PR TITLE
Stateless implicit return

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -62,6 +62,12 @@
     "description": "Creates a stateless React component as a named function with PropTypes"
   },
 
+  "reactStatelessImplicitReturn": {
+    "prefix": "rsi",
+    "body": "import React from 'react';\n\nconst ${1:${TM_FILENAME_BASE}} = (props) => (\n\t\t\t$0\n\t);\n\nexport default ${1:${TM_FILENAME_BASE}};",
+    "description": "Creates a stateless React component without PropTypes and ES6 module system with Implicit Return and props"
+  },
+
   "classConstructor": {
     "prefix": "con",
     "body": "constructor(props) {\n\tsuper(props);\n\t$0\n}\n",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -65,7 +65,7 @@
   "reactStatelessImplicitReturn": {
     "prefix": "rsi",
     "body": "import React from 'react';\n\nconst ${1:${TM_FILENAME_BASE}} = (props) => (\n\t\t\t$0\n\t);\n\nexport default ${1:${TM_FILENAME_BASE}};",
-    "description": "Creates a stateless React component without PropTypes and ES6 module system with Implicit Return and props"
+    "description": "Creates a stateless React component without PropTypes and ES6 module system but with Implicit Return and props"
   },
 
   "classConstructor": {


### PR DESCRIPTION
Added a new stateless with props and implicit return snippet:
```
import React from 'react';

const Logo = (props) => (
      
  );

export default Logo;
```